### PR TITLE
Add ability to filter RS Wikia results from Google search

### DIFF
--- a/background.js
+++ b/background.js
@@ -4,22 +4,9 @@
   let isPluginDisabled = false;
   let storage = window.storage || chrome.storage;
 
-<<<<<<< master
   const RSWIKIA_REGEX = /^(runescape|oldschoolrunescape)\.(wikia|fandom)\.com$/i;
-=======
-  const RSWIKIA_REGEX = /^(http|https):\/\/([^\.]+)\.(wikia|fandom)\.com(.*)$/i;
 
-  const REDIRECTS = {
-    "oldschoolrunescape":"oldschool.runescape.wiki",
-    "runescape":"runescape.wiki"
-  };
-
-  function splitURL(url){
-    return RSWIKIA_REGEX.exec(url);
-  }/*
->>>>>>> master
-
-  chrome.webRequest.onBeforeRequest.addListener(
+  chrome.webNavigation.onBeforeNavigate.addListener(
     function(info) {
       if(isPluginDisabled) {
         console.log("RSWikia intercepted, ignoring because plugin is disabled.");
@@ -33,51 +20,12 @@
       if (!isWikia) return;
 
       // Generate new url
-<<<<<<< master
-
       const host = url.host.includes('oldschool') ? 'oldschool.runescape' : 'runescape'
       const redirectUrl = `https://${host}.wiki${url.pathname.replace(/^\/wiki\//i,"/w/")}`;
       console.log(`RSWikia intercepted:  ${info.url}\nRedirecting to ${redirectUrl}`);
       // Redirect the old wikia request to new wiki
-=======
-      let redirectUrl = "https://"+newDomain+splitUrl[4].replace(/^\/wiki\//i,"/w/");
-      console.log("RSWikia intercepted: " + info.url + "\nRedirecting to "+redirectUrl);
-      // Redirect the old wikia request to new wiki 
->>>>>>> master
-      return {redirectUrl:redirectUrl};
-    },
-    // filters
-    {
-      urls: [
-        "*://oldschoolrunescape.wikia.com/*",
-        "*://runescape.wikia.com/*",
-        "*://oldschoolrunescape.fandom.com/*",
-        "*://runescape.fandom.com/*",
-      ]
-    },
-    // extraInfoSpec
-    ["blocking"]);*/
-
-  chrome.webNavigation.onBeforeNavigate.addListener( function (details) {
-    var tabId = details.tabId;
-    var tabUrl = details.url;
-    if(RSWIKIA_REGEX.test(tabUrl)) {
-      let splitUrl = splitURL(tabUrl);
-      let newDomain = REDIRECTS[splitUrl[2]];
-      // If domain isn't subdomain of wikia.com, ignore, also if it's not in the redirect filter
-      if(splitUrl===null || newDomain===undefined) return;
-      // Check if plugin is disabled, if so put a message logged
-      if(isPluginDisabled) {
-        console.log("RSWikia intercepted, ignoring because plugin is disabled.");
-        return;
-      }
-      // Generate new url
-      let redirectUrl = "https://"+newDomain+splitUrl[4].replace(/^\/wiki\//i,"/w/");
-      console.log("RSWikia intercepted: " + tabUrl + "\nRedirecting to "+redirectUrl);
-      // Redirect the old wikia request to new wiki 
-      chrome.tabs.update(tabId,{url:redirectUrl});
-    }
-})
+      chrome.tabs.update(info.tabId,{url:redirectUrl});
+    });
 
   function updateIcon(){
     chrome.browserAction.setIcon({ path: isPluginDisabled?"icon32_black.png":"icon32.png"  });

--- a/background.js
+++ b/background.js
@@ -1,36 +1,30 @@
 // Simple extension to redirect all requests to RS Wikia to RS Wiki
 (function(){
   'use strict';
-  var isPluginDisabled = false;
-
+  let isPluginDisabled = false;
   let storage = window.storage || chrome.storage;
 
-  const RSWIKIA_REGEX = /^(http|https):\/\/([^\.]+)\.(wikia|fandom)\.com(.*)$/i;
-
-  const REDIRECTS = {
-    "oldschoolrunescape":"oldschool.runescape.wiki",
-    "runescape":"runescape.wiki"
-  };
-
-  function splitURL(url){
-    return RSWIKIA_REGEX.exec(url);
-  }
+  const RSWIKIA_REGEX = /^(runescape|oldschoolrunescape)\.(wikia|fandom)\.com$/i;
 
   chrome.webRequest.onBeforeRequest.addListener(
     function(info) {
-      let splitUrl = splitURL(info.url);
-      let newDomain = REDIRECTS[splitUrl[2]];
-      // If domain isn't subdomain of wikia.com, ignore, also if it's not in the redirect filter
-      if(splitUrl===null || newDomain===undefined) return;
-      // Check if plugin is disabled, if so put a message logged
       if(isPluginDisabled) {
         console.log("RSWikia intercepted, ignoring because plugin is disabled.");
         return;
       }
+
+      const url = new URL(info.url);
+
+      const isWikia = RSWIKIA_REGEX.test(url.host); // is this necessary? we already filter by URL
+      // If domain isn't subdomain of wikia.com, ignore, also if it's not in the redirect filter
+      if (!isWikia) return;
+
       // Generate new url
-      let redirectUrl = "https://"+newDomain+splitUrl[4].replace(/^\/wiki\//i,"/w/");
-      console.log("RSWikia intercepted: " + info.url + "\nRedirecting to "+redirectUrl);
-      // Redirect the old wikia request to new wiki	
+
+      const host = url.host.includes('oldschool') ? 'oldschool.runescape' : 'runescape'
+      const redirectUrl = `https://${host}.wiki${url.pathname.replace(/^\/wiki\//i,"/w/")}`;
+      console.log(`RSWikia intercepted:  ${info.url}\nRedirecting to ${redirectUrl}`);
+      // Redirect the old wikia request to new wiki
       return {redirectUrl:redirectUrl};
     },
     // filters
@@ -39,21 +33,18 @@
         "*://oldschoolrunescape.wikia.com/*",
         "*://runescape.wikia.com/*",
         "*://oldschoolrunescape.fandom.com/*",
-        "*://runescape.fandom.com/*"
+        "*://runescape.fandom.com/*",
       ]
     },
     // extraInfoSpec
     ["blocking"]);
 
   function updateIcon(){
-    chrome.browserAction.setIcon({  path: isPluginDisabled?"icon32_black.png":"icon32.png"  });
+    chrome.browserAction.setIcon({ path: isPluginDisabled?"icon32_black.png":"icon32.png"  });
   }
 
   storage.local.get(['isDisabled'],(result)=>{
-      if(result===undefined) {
-        result={isDisabled:false};
-      }
-      isPluginDisabled=result.isDisabled;
+      isPluginDisabled= result ? result.isDisabled : false;
       updateIcon();
   });
 
@@ -61,7 +52,7 @@
       function(changes, areaName) {
         // If isDisabled changed, update isPluginDisabled
         if(changes["isDisabled"]!==undefined && changes["isDisabled"].newValue!=changes["isDisabled"].oldValue) {
-          console.log("RS Wiki Redirector is now "+(changes["isDisabled"].newValue?"disabled":"enabled")+".");
+          console.log(`RS Wiki Redirector is now ${changes["isDisabled"].newValue?'disabled':'enabled'}`);
           isPluginDisabled=changes["isDisabled"].newValue;
           updateIcon();
         }

--- a/manifest.json
+++ b/manifest.json
@@ -7,24 +7,33 @@
                   "*://oldschoolrunescape.wikia.com/*",
                   "*://runescape.wikia.com/*",
                   "*://oldschoolrunescape.fandom.com/*",
-                  "*://runescape.fandom.com/*"],
+                  "*://runescape.fandom.com/*"
+                ],
 
   "applications": {
     "gecko" : {
       "id": "{c3cc188f-ea35-4519-a09c-72e8f06b5d11}"
     }
   },
-  
+
   "background": {
     "scripts": ["background.js"],
     "persistent": true
   },
-  
+
   "browser_action": {
     "default_icon": "icon32.png",
     "default_title": "RS Wiki Redirector",
     "default_popup": "popup.html"
   },
+
+  "content_scripts": [
+    {
+      "matches": ["*://*.google.com/*"],
+      "js": ["searchFilter.js"],
+      "run_at": "document_end"
+    }
+  ],
 
   "icons":{
   	 "48": "icon48.png",

--- a/manifest.json
+++ b/manifest.json
@@ -7,14 +7,10 @@
                   "*://oldschoolrunescape.wikia.com/*",
                   "*://runescape.wikia.com/*",
                   "*://oldschoolrunescape.fandom.com/*",
-<<<<<<< master
-                  "*://runescape.fandom.com/*"
-                ],
-=======
                   "*://runescape.fandom.com/*",
                   "webNavigation",
-                  "tabs"],
->>>>>>> master
+                  "tabs"
+                 ],
 
   "applications": {
     "gecko" : {
@@ -35,7 +31,7 @@
 
   "content_scripts": [
     {
-      "matches": ["*://*.google.com/*"],
+      "matches": ["*://*.google.*/*"],
       "js": ["searchFilter.js"],
       "run_at": "document_end"
     }

--- a/popup.html
+++ b/popup.html
@@ -26,10 +26,11 @@
 		</style>
 	</head>
 	<body>
-		<div id="addonStateImage"></div>
 		<p style="text-align:center">
 			Currently the RS Wiki Redirector extension is <span id="addonStateDescriptor">disabled</span>.
 		</p>
+		<div id="addonStateImage"></div>
+		<input type="checkbox" name="hideWikia" id="hideWikiaCheck" /> Hide Wikia results in search
 		<script type="text/javascript" src="popup.js"></script>
 	</body>
 </html>

--- a/popup.js
+++ b/popup.js
@@ -1,36 +1,40 @@
-(function(){
+(function () {
 	let storage = window.storage || chrome.storage;
 	let stateImage = document.getElementById("addonStateImage");
 
-	if(stateImage==null)
-	{
+	if (stateImage === null) {
 		console.error("Something went wrong!");
 		return;
 	}
-	function toggle()
-	{
-			let prom = storage.local.set({isDisabled:!currentState});
-			if(window.Promise && prom instanceof Promise) {
-				prom.reject(()=>{});
-			}
-			update();
+	function toggle() {
+		let prom = storage.local.set({ isDisabled: !currentState });
+		if (prom instanceof Promise) {
+			prom.reject();
+		}
+		update();
 	}
-	stateImage.addEventListener("click",toggle)
+	stateImage.addEventListener("click", toggle)
 	let stateDesc = document.getElementById("addonStateDescriptor");
-	if(stateDesc==null)
-	{
+	if (stateDesc === null) {
 		console.error("Something went wrong!");
 		return;
 	}
-	window.update = function() {
-		storage.local.get(['isDisabled'], function(result){
-			if(result===undefined) {
-				result={isDisabled:false};
+
+	const hideWikiaCheck = document.querySelector("#hideWikiaCheck")
+	hideWikiaCheck.addEventListener("click", (e) => {
+		storage.local.set({ hideWikia: e.target.checked });
+	});
+
+	window.update = function () {
+		storage.local.get(['isDisabled', 'hideWikia'], function (result) {
+			if (result === undefined) {
+				result = { isDisabled: false, hideWikia: true };
 			}
-			window.currentState = result.isDisabled==true;
-			stateImage.style.backgroundImage = "url('powerbutton_"+(result.isDisabled?"off":"on")+".png')";
-			stateDesc.innerHTML = result.isDisabled?"disabled":"enabled";
-			stateDesc.style.color = result.isDisabled?"#7C1D1D":"#217A3D";
+			window.currentState = result.isDisabled === true;
+			stateImage.style.backgroundImage = "url('powerbutton_" + (result.isDisabled ? "off" : "on") + ".png')";
+			stateDesc.innerHTML = result.isDisabled ? "disabled" : "enabled";
+			stateDesc.style.color = result.isDisabled ? "#7C1D1D" : "#217A3D";
+			hideWikiaCheck.checked = result.hideWikia;
 		});
 	}
 	update();

--- a/searchFilter.js
+++ b/searchFilter.js
@@ -1,0 +1,22 @@
+(function() {
+  const storage = window.storage || chrome.storage;
+
+  storage.local.get(['hideWikia'], (result) => {
+    if (result && result.hideWikia) {
+      const wikiaLinks = document.querySelectorAll('[href*="runescape.fandom"], [href*="runescape.wikia"]');
+
+      // recursively go up through tree until getting relevant div to remove
+      function getParent(element, maxDepth = 10) {
+        if (element.parentElement) {
+          if (element.parentElement.className === 'g') {
+            element.remove();
+          } else {
+            getParent(element.parentElement, maxDepth - 1);
+          }
+        }
+      }
+
+      wikiaLinks.forEach((e) => getParent(e));
+    }
+  });
+})();


### PR DESCRIPTION
**Add ability to filter RS Wikia results from Google search**

Motivation: as per #1 there are concerns around clicking on wikia links (then redirecting) having a positive effect on the wikia page rank. This PR attempts to resolve this by scanning the page for RS wikia results, and deleting them.

- searchFilter.js: this is a content script which runs on `document_end`, scans the page for any wikia links, then recursively traverses the DOM to find the relevant div to remove from the tree. Conditionally executes based on the user's settings.

- popup.js/popup.html: adding a new checkbox to turn on/off the hiding of wikia results.

- background.js: saw an opportunity to optimise up the URL parsing by using the native URL object.


If anyone has any alternative ideas on how to hide wikia results, please share. I did play with the idea of intercepting Google searches, parsing the URLSearchParams, and appending `-site:runescape.fandom.com`, but that appearing in the search bar could get pretty ugly for the user.